### PR TITLE
Changing namespace of bind function to globally

### DIFF
--- a/src/TCPServer.cpp
+++ b/src/TCPServer.cpp
@@ -70,7 +70,7 @@ int TCPServer::setup(int port, vector<int> opts)
 	serverAddress.sin_addr.s_addr = htonl(INADDR_ANY);
 	serverAddress.sin_port        = htons(port);
 
-	if((bind(sockfd,(struct sockaddr *)&serverAddress, sizeof(serverAddress))) < 0){
+	if((::bind(sockfd,(struct sockaddr *)&serverAddress, sizeof(serverAddress))) < 0){
 		cerr << "Errore bind" << endl;
 		return -1;
 	}


### PR DESCRIPTION
Hi
I'm Mac User, And While I studied the server, I saw your project.

I Install c++ complier through Xcode, So bind Function conflict with other in functional.cpp

below the same issue with me 
https://stackoverflow.com/questions/16180322/c-xcode-sockets-bind-error

Of course, the operating system is not Linux, but I think this fix can be used by Mac users.

If you have a problem with Linux, you might be able to create a new branch